### PR TITLE
Remove Google Fonts import and correct background image path

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap");
 * {
   box-sizing: border-box;
 }
@@ -21,7 +20,7 @@ body {
   font-family: "Montserrat", sans-serif;
   margin: 100px;
   padding: 0;
-  background-image: url("/public/F20_Pharma_Pattern-Hexagon_07.png");
+  background-image: url("/F20_Pharma_Pattern-Hexagon_07.png");
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- remove Google Fonts @import from stylesheet
- point background-image to root-level path

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aeaec70bd0832c91d81fa83ee64678