### PR TITLE
StrainSimilarity: add discontinued visibility toggle, refactor visibility check, and refresh UI/styles

### DIFF
--- a/src/components/StrainSimilarity.jsx
+++ b/src/components/StrainSimilarity.jsx
@@ -6,15 +6,10 @@ import {
   parseParents,
 } from "../utils/helpers";
 
-/* helper: determine whether a strain is considered "active" (same logic as filters) */
-function isActiveStrain(s = {}) {
-  const status = (s.status || s.statut || s.aktiv || "").toString().toLowerCase();
-  if (status) {
-    if (status === "active" || status === "aktiv" || status === "true") return true;
-    // "inactive" and "discontinued" are not considered active
-    return false;
-  }
-  if (s.active === true) return true;
+function isStrainVisible(strain = {}, includeDiscontinued = false) {
+  const status = (strain.status || "").toString().trim().toLowerCase();
+  if (status === "active") return true;
+  if (includeDiscontinued && status === "discontinued") return true;
   return false;
 }
 
@@ -260,12 +255,9 @@ export default function StrainSimilarity({
     [kultivare, aliasLookup]
   );
 
-  // only consider active strains for dropdown / comparisons unless discontinued should be included
   const selectableStrains = useMemo(() => {
-    const filtered = (
-      includeDiscontinued
-        ? strainsWithNormalizedTerpenes
-        : strainsWithNormalizedTerpenes.filter(isActiveStrain)
+    const filtered = strainsWithNormalizedTerpenes.filter((strain) =>
+      isStrainVisible(strain, includeDiscontinued)
     ).filter(
       (strain) =>
         strain.normalizedTerpenes.length > 0 ||
@@ -363,7 +355,7 @@ export default function StrainSimilarity({
   useEffect(() => {
     if (!includeDiscontinued && selectedName) {
       const selected = kultivare.find((k) => k.name === selectedName);
-      if (selected && !isActiveStrain(selected)) {
+      if (selected && !isStrainVisible(selected, false)) {
         handleClear();
       }
     }
@@ -440,64 +432,78 @@ export default function StrainSimilarity({
 
   return (
     <section className="similarity-panel">
-      <h3 id="similarity-panel-title" className="similarity-panel__title">
-        Ähnliche Sorte finden
-      </h3>
+      <div className="similarity-panel__header">
+        <h3 id="similarity-panel-title" className="similarity-panel__title">
+          Ähnliche Sorte finden
+        </h3>
+        <p id="strain-select-note" className="similarity-panel__description">
+          Tippen Sie, um eine Referenzsorte zu finden. Die Suche filtert live und nutzt
+          Terpenprofil, Genetik sowie Geruchs- und Aromadaten als Basis.
+        </p>
+      </div>
+
       <div className="similarity-panel__controls">
-        <label className="similarity-panel__label" htmlFor="strain-combobox">
-          Sorte wählen
-        </label>
-        <div className="similarity-panel__combobox">
-          <input
-            id="strain-combobox"
-            className="similarity-panel__input"
-            type="text"
-            role="combobox"
-            aria-autocomplete="list"
-            aria-expanded={isOpen}
-            aria-controls={listboxId}
-            aria-activedescendant={activeDescendantId}
-            aria-labelledby="similarity-panel-title"
-            aria-describedby="strain-select-note"
-            placeholder="Sorte wählen …"
-            value={query}
-            onChange={handleChange}
-            onFocus={() => setIsOpen(true)}
-            onBlur={() => {
-              window.setTimeout(() => setIsOpen(false), 100);
-            }}
-            onKeyDown={handleKeyDown}
-          />
-          {isOpen && (
-            <ul className="similarity-panel__list" role="listbox" id={listboxId}>
-              {filteredStrains.length ? (
-                filteredStrains.map((strain, index) => {
-                  const isActive = index === activeIndex;
-                  return (
-                    <li
-                      key={strain.name}
-                      id={`${listboxId}-option-${index}`}
-                      role="option"
-                      aria-selected={isActive}
-                      className={`similarity-panel__option ${isActive ? "is-active" : ""}`.trim()}
-                      onMouseDown={(event) => {
-                        event.preventDefault();
-                        handleSelect(strain.name);
-                      }}
-                      onMouseEnter={() => setActiveIndex(index)}
-                    >
-                      {strain.name}
-                    </li>
-                  );
-                })
-              ) : (
-                <li className="similarity-panel__option is-empty" role="option" aria-selected="false">
-                  Keine Treffer
-                </li>
-              )}
-            </ul>
-          )}
+        <div className="similarity-panel__search-field">
+          <label className="similarity-panel__label" htmlFor="strain-combobox">
+            Sorte wählen
+          </label>
+          <div className="similarity-panel__combobox">
+            <input
+              id="strain-combobox"
+              className="similarity-panel__input"
+              type="text"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={isOpen}
+              aria-controls={listboxId}
+              aria-activedescendant={activeDescendantId}
+              aria-labelledby="similarity-panel-title"
+              aria-describedby="strain-select-note"
+              placeholder="Sorte wählen …"
+              value={query}
+              onChange={handleChange}
+              onFocus={() => setIsOpen(true)}
+              onBlur={() => {
+                window.setTimeout(() => setIsOpen(false), 100);
+              }}
+              onKeyDown={handleKeyDown}
+            />
+            {isOpen && (
+              <ul className="similarity-panel__list" role="listbox" id={listboxId}>
+                {filteredStrains.length ? (
+                  filteredStrains.map((strain, index) => {
+                    const isActive = index === activeIndex;
+                    return (
+                      <li
+                        key={strain.name}
+                        id={`${listboxId}-option-${index}`}
+                        role="option"
+                        aria-selected={isActive}
+                        className={`similarity-panel__option ${isActive ? "is-active" : ""}`.trim()}
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                          handleSelect(strain.name);
+                        }}
+                        onMouseEnter={() => setActiveIndex(index)}
+                      >
+                        {strain.name}
+                      </li>
+                    );
+                  })
+                ) : (
+                  <li
+                    className="similarity-panel__option is-empty"
+                    role="option"
+                    aria-selected="false"
+                  >
+                    Keine Treffer
+                  </li>
+                )}
+              </ul>
+            )}
+          </div>
         </div>
+
         <button
           type="button"
           className="reset-btn similarity-panel__clear"
@@ -509,9 +515,6 @@ export default function StrainSimilarity({
         </button>
       </div>
 
-      <p id="strain-select-note" className="similarity-panel__description">
-        Tippen Sie, um eine Referenzsorte zu finden. Die Suche filtert live und nutzt Terpenprofil, Genetik sowie Geruchs- und Aromadaten als Basis.
-      </p>
       <p className="similarity-panel__description">
         Gewichtung: 75&nbsp;% Terpene, 15&nbsp;% Aroma, 10&nbsp;% Genetik.
       </p>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1701,49 +1701,82 @@ nav a:hover {
 
 .similarity-panel {
   margin: 0;
-  padding: 16px;
-  border: 1px solid #e0e0e0;
-  border-radius: 10px;
-  background: #ffffffcc;
-  box-shadow: 0 2px 6px rgba(55, 71, 79, 0.08);
+  padding: 20px;
+  border: 1px solid rgba(207, 216, 220, 0.9);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.94));
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.similarity-panel__header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  margin-bottom: 16px;
 }
 
 .similarity-panel__title {
-  text-align: center;
+  margin: 0;
+  text-align: left;
+}
+
+.similarity-panel__label {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #274252;
 }
 
 .similarity-panel__controls {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-end;
+  justify-content: flex-start;
+}
+
+.similarity-panel__search-field {
+  display: flex;
+  flex: 1 1 320px;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: min(100%, 320px);
 }
 
 .similarity-panel__description {
   margin: 8px 0 0;
   font-size: 13px;
   color: #546e7a;
-  text-align: center;
+  text-align: left;
+  max-width: 72ch;
 }
 
 .similarity-panel__combobox {
   position: relative;
-  flex: 0 1 320px;
+  width: min(100%, 360px);
 }
 
 .similarity-panel__input {
   width: 100%;
-  padding: 10px 14px;
+  min-height: 46px;
+  padding: 10px 16px;
   border-radius: 999px;
-  border: 1px solid #b0bec5;
+  border: 1px solid #b9c6cf;
   background: #fff;
   font-size: 14px;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .similarity-panel__input:focus {
+  border-color: rgba(0, 85, 164, 0.55);
   outline: 2px solid rgba(0, 85, 164, 0.4);
   outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(0, 85, 164, 0.08);
+  transform: translateY(-1px);
 }
 
 .similarity-panel__list {
@@ -1784,7 +1817,8 @@ nav a:hover {
 
 .similarity-panel__clear {
   flex: 0 0 auto;
-  align-self: flex-start;
+  min-height: 46px;
+  align-self: flex-end;
 }
 
 .similarity-panel__clear:disabled {
@@ -1800,6 +1834,22 @@ nav a:hover {
 
 .similarity-panel__status {
   margin-top: 16px;
+}
+
+@media (max-width: 640px) {
+  .similarity-panel {
+    padding: 16px;
+  }
+
+  .similarity-panel__search-field,
+  .similarity-panel__combobox {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .similarity-panel__clear {
+    align-self: stretch;
+  }
 }
 
 .view-switcher {


### PR DESCRIPTION
### Motivation

- Treat discontinued strains as a configurable visibility option and simplify the active/visibility check logic to be explicit about included statuses.
- Improve the usability and visual design of the similarity panel, clarify instructions, and tidy up ARIA/label structure for the combobox.

### Description

- Replace `isActiveStrain` with `isStrainVisible(strain, includeDiscontinued)` and update all filters and `useEffect` checks to use the new function and explicit `includeDiscontinued` handling.
- Change selectable strain filtering to use `isStrainVisible` and keep only strains that have terpene, genetics, smell, or aroma data for selection.
- Restructure the markup for the similarity control area by adding a header paragraph, wrapping the label/input in `.similarity-panel__search-field`, and moving the descriptive note into the header while keeping `aria-describedby` references.
- Overhaul styles in `styles.css` for `.similarity-panel` and related classes: new rounded card background, updated spacing, label/input/list styling, focus states, responsive tweaks, and new helper classes like `.similarity-panel__header` and `.similarity-panel__label`.

### Testing

- Ran unit tests with `npm test` (Jest) and all tests passed.
- Ran linting with `npm run lint` (ESLint) and no lint errors were reported.
- Built the app with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7db5b934c832c83454de3c2d44aba)