### PR TITLE
[Ersetzt] Fehlendes validate:data-Skript ergänzen

### DIFF
--- a/.github/workflows/validate-refs.yml
+++ b/.github/workflows/validate-refs.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci || npm i
 
       - name: Validate data (offline)
-        run: npm run validate:data
+        run: npm run validate
 
       - name: Validate references (online)
         run: SLOW_MS=300 npm run validate:refs
@@ -33,5 +33,3 @@ jobs:
         with:
           name: references-online-report
           path: reports/references-online-report.json
-
-

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "react-scripts start",
     "validate": "node scripts/validate.mjs",
+    "validate:data": "node scripts/validate.mjs",
     "validate:backups": "node scripts/validate-backups.mjs",
     "validate:refs": "node scripts/validate-refs-online.mjs",
     "audit:scripts": "node scripts/audit-scripts.mjs",


### PR DESCRIPTION
Dieser Ansatz wurde verworfen. Statt eines zusätzlichen npm-Alias wird der Workflow direkt auf das bereits vorhandene Skript `npm run validate` umgestellt.