### PR TITLE
Referenz-Workflow korrigieren

### DIFF
--- a/.github/workflows/validate-refs.yml
+++ b/.github/workflows/validate-refs.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci || npm i
 
       - name: Validate data (offline)
-        run: npm run validate:data
+        run: npm run validate
 
       - name: Validate references (online)
         run: SLOW_MS=300 npm run validate:refs
@@ -33,5 +33,3 @@ jobs:
         with:
           name: references-online-report
           path: reports/references-online-report.json
-
-

--- a/.github/workflows/validate-refs.yml
+++ b/.github/workflows/validate-refs.yml
@@ -32,4 +32,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: references-online-report
-          path: reports/references-online-report.json
+          path: |
+            reports/references-online-report.json
+            public/kultivare.json
+            data/kultivare.json.bak


### PR DESCRIPTION
Der Workflow verwendet jetzt das bereits vorhandene npm-Skript `validate` statt des nicht definierten Befehls `validate:data`. Dadurch bleibt die Offline-Datenvalidierung erhalten, ohne einen zusätzlichen Alias in der package.json einzuführen.